### PR TITLE
refactor: apply cargo clippy suggestions

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ pub fn get_executable(client: &RpcClient, program_id: &Pubkey) -> Result<Vec<u8>
             _ => Err(anyhow!("Invalid program id, unknown account state")),
         }
     } else if account.owner == bpf_loader::id() || account.owner == bpf_loader_deprecated::id() {
-        Ok(account.data.to_vec())
+        Ok(account.data.clone())
     } else {
         Err(anyhow!("Invalid program id, unknown program owner"))
     }

--- a/src/dynamic_analysis.rs
+++ b/src/dynamic_analysis.rs
@@ -39,7 +39,7 @@ impl ContextObject for TestContextObject {
 
 impl TestContextObject {
     /// Initialize with instruction meter
-    pub fn new(remaining: u64) -> Self {
+    pub const fn new(remaining: u64) -> Self {
         Self {
             trace_log: Vec::new(),
             remaining,
@@ -70,7 +70,7 @@ pub fn extract_args(executable_data: &[u8], entrypoint: usize) -> Vec<ArgMeta> {
 
     let mut hash = 0u64;
     let mut fields = vec![];
-    
+
     // TODO: handle vector
     for length in 0u64..1000 {
         let mut stack: AlignedMemory<{ HOST_ALIGN }> =
@@ -119,7 +119,7 @@ pub fn extract_args(executable_data: &[u8], entrypoint: usize) -> Vec<ArgMeta> {
         interpreter.reg[11] += 1;
         while interpreter.step() {
             let pc = interpreter.reg[11];
-            let insn = ebpf::get_insn_unchecked(program, pc as usize);
+            let insn = ebpf::get_insn_unchecked(program, usize::try_from(pc).unwrap());
             if insn.opc == ebpf::CALL_IMM {
                 break;
             }
@@ -134,7 +134,7 @@ pub fn extract_args(executable_data: &[u8], entrypoint: usize) -> Vec<ArgMeta> {
     let mut args = vec![];
     for idx in 0..fields.len() - 1 {
         args.push(ArgMeta {
-            name: format!("field_{}", idx),
+            name: format!("field_{idx}"),
             ty: match fields[idx + 1] - fields[idx] {
                 1 => "u8".to_string(),
                 2 => "u16".to_string(),
@@ -142,7 +142,7 @@ pub fn extract_args(executable_data: &[u8], entrypoint: usize) -> Vec<ArgMeta> {
                 8 => "u64".to_string(),
                 16 => "u128".to_string(),
                 32 => "pubkey".to_string(),
-                x => format!("[u8; {}]", x),
+                x => format!("[u8; {x}]"),
             },
         });
     }
@@ -169,7 +169,7 @@ pub fn extract_types(
     for (account_name, &entrypoint) in deserializers {
         let mut hash = 0u64;
         let mut fields = vec![];
-        
+
         // TODO: handle vector
         for length in 0u64..1000 {
             let mut stack: AlignedMemory<{ HOST_ALIGN }> =
@@ -218,7 +218,7 @@ pub fn extract_types(
             interpreter.reg[11] += 1;
             while interpreter.step() {
                 let pc = interpreter.reg[11];
-                let insn = ebpf::get_insn_unchecked(program, pc as usize);
+                let insn = ebpf::get_insn_unchecked(program, usize::try_from(pc).unwrap());
                 if insn.opc == ebpf::CALL_IMM {
                     break;
                 }
@@ -241,7 +241,7 @@ pub fn extract_types(
                     8 => "u64".to_string(),
                     16 => "u128".to_string(),
                     32 => "pubkey".to_string(),
-                    x => format!("[u8; {}]", x),
+                    x => format!("[u8; {x}]"),
                 },
             });
         }

--- a/src/idl.rs
+++ b/src/idl.rs
@@ -13,7 +13,7 @@ pub struct Idl {
     pub types: Vec<IDLType>,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct Metadata {
     pub name: String,
     pub version: String,
@@ -21,13 +21,13 @@ pub struct Metadata {
     pub description: String,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct IDLAccount {
     pub name: String,
     pub discriminator: [u8; 8],
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct IDLError {
     pub code: u32,
     pub name: String,
@@ -41,13 +41,13 @@ pub struct IDLType {
     pub ty: InnerType,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct InnerType {
     pub kind: String,
     pub fields: Vec<ArgMeta>,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct InstructionInfo {
     pub name: String,
     pub discriminator: [u8; 8],
@@ -55,14 +55,14 @@ pub struct InstructionInfo {
     pub args: Vec<ArgMeta>,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct ArgMeta {
     pub name: String,
     #[serde(rename = "type")]
     pub ty: String,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct AccountMeta {
     pub name: String,
     #[serde(skip_serializing_if = "is_false")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,10 +46,10 @@ fn main() -> Result<()> {
 
     if !opts.force_guess {
         if let Ok(account) = client::get_idl_account(&client, &program_id) {
-            let idl_path = format!("{}.json", program_id);
+            let idl_path = format!("{program_id}.json");
             let mut file = File::create(&idl_path)?;
             file.write_all(serde_json::to_string_pretty(&account)?.as_bytes())?;
-            println!("Public IDL found for {}, saved to {}", program_id, idl_path);
+            println!("Public IDL found for {program_id}, saved to {idl_path}");
             return Ok(());
         }
     }
@@ -106,7 +106,7 @@ fn main() -> Result<()> {
         .collect();
 
     let (call_graph, reference_graph) =
-        generate_call_graph(&executable, &function_ranges, &instructions)?;
+        generate_call_graph(&executable, &function_ranges, &instructions);
 
     let (instruction_handlers, possible_signer_error) = find_instruction_handlers(
         &executable,
@@ -125,7 +125,7 @@ fn main() -> Result<()> {
     debug!("possible_signer_error: {:?}", possible_signer_error);
 
     let signer_try_from_pc = match possible_signer_error {
-        Some(pc) => reference_graph.get(&pc).and_then(|x| x.first().cloned()),
+        Some(pc) => reference_graph.get(&pc).and_then(|x| x.first().copied()),
         None => None,
     };
     debug!("signer_try_from_pc: {:?}", signer_try_from_pc);
@@ -155,7 +155,7 @@ fn main() -> Result<()> {
                         .map(|(_, insn)| insn)
                         .collect::<Vec<&ebpf::Insn>>(),
                     function_registry,
-                    &sbpf_version,
+                    sbpf_version,
                     &executable_data,
                     signer_try_from_pc,
                 )
@@ -187,11 +187,11 @@ fn main() -> Result<()> {
         types: extract_types(&executable_data, &deserializers),
     };
 
-    println!("Generated IDL for {}", program_id);
-    let idl_path = format!("{}.json", program_id);
+    println!("Generated IDL for {program_id}");
+    let idl_path = format!("{program_id}.json");
     let mut file = File::create(&idl_path)?;
     file.write_all(serde_json::to_string_pretty(&idl)?.as_bytes())?;
-    println!("Saved IDL to {}", idl_path);
+    println!("Saved IDL to {idl_path}");
 
     Ok(())
 }


### PR DESCRIPTION
### Problem
rust linter [clippy](https://github.com/rust-lang/rust-clippy) has an enormous number of suggestions for style, code-complexity, and possible pitfalls

### Solution
run `cargo clippy` command and apply all the suggestions

cc @LeoQ7 